### PR TITLE
Fix punctuation returning error

### DIFF
--- a/pleco_to_anki/pleco/All_Bookmarks.py
+++ b/pleco_to_anki/pleco/All_Bookmarks.py
@@ -51,4 +51,4 @@ def category_heading(row : str) -> bool:
 
 #print(load_pleco_data("exampledata.txt")[5].get("Hanzi"))
 
-print(load_pleco_data("D:/Projekte/Pleco-to-Anki/pleco_to_anki/exampledata2.txt"))
+print(load_pleco_data("exampledata2.txt"))

--- a/pleco_to_anki/tones/numerical_pinyin_converter.py
+++ b/pleco_to_anki/tones/numerical_pinyin_converter.py
@@ -101,6 +101,9 @@ def convert_indiv_character(indiv_character):
         # If the character is r5 (儿), remove tone number and return
         if letter_list == ["r", "5"]:
             return "".join(letter_list[:-1])
+        elif all(map(lambda c: c in ' .?!。？！', letter_list)):
+            debug("Found punctuation: ", indiv_character)
+            return indiv_character
         else:
             raise ValueError("Invalid numerical pinyin. Input does not contain a vowel.")
 


### PR DESCRIPTION
- Fix punctuation returning error when converting numerical pinyin
- Fix absolute path when attempting to print example file (I don't know the purpose of it, I only fixed the error)

Line endings got converted to LF, which is the standard. It screws with the diff but the changes are the following:
```diff
# git diff --patch --ignore-cr-at-eol origin/main HEAD
diff --git a/pleco_to_anki/pleco/All_Bookmarks.py b/pleco_to_anki/pleco/All_Bookmarks.py
index 9b91c69..787001b 100644
--- a/pleco_to_anki/pleco/All_Bookmarks.py
+++ b/pleco_to_anki/pleco/All_Bookmarks.py
@@ -51,4 +51,4 @@ def category_heading(row : str) -> bool:
 
 #print(load_pleco_data("exampledata.txt")[5].get("Hanzi"))
 
-print(load_pleco_data("D:/Projekte/Pleco-to-Anki/pleco_to_anki/exampledata2.txt"))
\ No newline at end of file
+print(load_pleco_data("exampledata2.txt"))
diff --git a/pleco_to_anki/tones/numerical_pinyin_converter.py b/pleco_to_anki/tones/numerical_pinyin_converter.py
index a45d44d..8530d44 100644
--- a/pleco_to_anki/tones/numerical_pinyin_converter.py
+++ b/pleco_to_anki/tones/numerical_pinyin_converter.py
@@ -101,6 +101,9 @@ def convert_indiv_character(indiv_character):
         # If the character is r5 (儿), remove tone number and return
         if letter_list == ["r", "5"]:
             return "".join(letter_list[:-1])
+        elif all(map(lambda c: c in ' .?!。？！', letter_list)):
+            debug("Found punctuation: ", indiv_character)
+            return indiv_character
         else:
             raise ValueError("Invalid numerical pinyin. Input does not contain a vowel.")
```