### PR TITLE
Transform uppercase vowels when converting indiv characters

### DIFF
--- a/pleco_to_anki/tones/numerical_pinyin_converter.py
+++ b/pleco_to_anki/tones/numerical_pinyin_converter.py
@@ -65,6 +65,9 @@ def convert_indiv_character(indiv_character):
     # Convert indiv char string into list of letters
     letter_list = list(indiv_character)
 
+    # Lowercase all letters (e.g. country names start with a capital letter)
+    letter_list = [w.lower() for w in letter_list]
+
     # Identify v letters, convert to ü
     for index, letter in enumerate(letter_list):
         if letter == 'v':


### PR DESCRIPTION
Hey,

thank you for the plugin, it really helped me a lot.

There is however one issue when importing words that contain capital vowels, such as country names (e.g. E2luo2si1 -> Russia).

See this exception:

```
Traceback (most recent call last):
  File "/Anki2/addons21/pleco_to_anki/__init__.py", line 60, in excecuted_function
    bookmark = Bookmark(slice, configs)
  File "/Anki2/addons21/pleco_to_anki/pleco/Bookmark.py", line 14, in __init__
    self.pinyin_pretty = convert_from_numerical_pinyin(self.pinyin_ugly)
  File "/Anki2/addons21/pleco_to_anki/tones/numerical_pinyin_converter.py", line 47, in convert_from_numerical_pinyin
    finished_char = convert_indiv_character(indiv_character)
  File "/Anki2/addons21/pleco_to_anki/tones/numerical_pinyin_converter.py", line 105, in convert_indiv_character
    raise ValueError("Invalid numerical pinyin. Input does not contain a vowel")
ValueError: Invalid numerical pinyin. Input does not contain a vowel.

```

Capital vowels are not recognized as vowels currently. I'd propose with this PR to just lowercase the input when converting the indiv char to tone marked chars, because I don't feel like the capitalization is important.

Cheers!